### PR TITLE
fix(ci): 别让跳过的运行取消真正的索引构建

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -2,13 +2,21 @@ name: Build index
 on:
   push:
     branches: [main]
+    # 送花只改 _flowers.json，跟索引无关。这里就把它挡在门外，连运行都不创建：
+    # 光靠下面 job 的 if 跳过是不够的——跳过也得先进 concurrency 组，
+    # 进组就会取消正在跑的真构建（见下）。
+    paths-ignore: ["_flowers.json"]
   workflow_dispatch:
 # App 的一次「编辑」会连发好几个提交（删旧文件、传新文件、说明、署名），
 # 每个提交各触发一次运行。不收敛的话它们会同时构建、竞争推送——只有一个
 # 推得上去，其余非快进失败；抢赢的还未必是最新提交，索引就停在旧状态。
 # 收敛成同组：新运行进来就取消还在跑的旧运行，永远只留最新一趟。
+#
+# 但 concurrency 是运行级的，job 的 if 是 job 级的：GitHub 先按组取消，
+# 再判断 if。所以一个什么都不做的运行照样能取消掉真构建，自己再跳过，
+# 结果没人重建索引。要跳过的运行必须拿到各自独立的组名，别碰 build-index。
 concurrency:
-  group: build-index
+  group: "build-index${{ (contains(github.event.head_commit.message, '[skip-index]') || github.actor == 'github-actions[bot]') && format('-noop-{0}', github.run_id) || '' }}"
   cancel-in-progress: true
 jobs:
   build:


### PR DESCRIPTION
## 问题

Actions 列表里大量运行显示为「取消」，索引经常没重建成功。

实锤：`资源/快捷指令模版/打开微信并截图快捷指令` 在仓库里存在，但 `_index.json` 里没有这条。本地重跑一遍 `scripts/build-index.mjs`，唯一新增的条目就是它。

## 根因

`concurrency` 是**运行级**的，job 的 `if` 是 **job 级**的。GitHub 先按 concurrency 组执行 `cancel-in-progress`，**之后**才判断 job 的 `if`。

于是一个送花提交（只改 `_flowers.json`、消息带 `[skip-index]`）创建的运行，会先挤进 `build-index` 组、取消掉正在跑的真构建，然后自己跳过、什么都不做 —— 没有任何一趟运行重建索引，`_index.json` 就停在旧状态。

现场时间线（run #10181~#10184）：

| 时间 | 运行 | 结果 |
| --- | --- | --- |
| 19:36:43 | 上架：打开微信并截图快捷指令/IMG_3165.jpeg | cancelled |
| 19:36:44 | 上架：打开微信并截图快捷指令/说明.txt | cancelled |
| 19:36:46 | 上架：打开微信并截图快捷指令/.owner | cancelled |
| 19:36:47 | 送花：手机电量感知 `[skip-index]` | skipped |

前三个互相取消是预期的收敛（最后一个会按 `main` 最新状态构建全量索引）。问题出在第四个：一个什么都不做的送花运行把最后那个真构建也取消了。

App 一次上架会连发好几个提交，后面恰好跟一条送花的概率不低 —— 这就是「经常失败」的来源。

## 改动

两道防线：

1. **`paths-ignore: ["_flowers.json"]`** —— 送花提交只动这一个文件（抽查历史确认），这样它连运行都不会创建，顺带让 Actions 列表不再被这些空跑刷屏。
2. **组名按「会不会跳过」分流** —— 会跳过的运行拿 `build-index-noop-<run_id>`，各自独占一组，碰不到真构建共用的 `build-index`。防止哪天送花提交碰巧还动了别的文件。

## 验证

- `actionlint` 通过；另外故意把 `github.run_id` 换成不存在的字段，确认它确实在校验这段 concurrency 表达式（会报错），排除「静默放过」。
- 表达式真值表已核对：真构建 → `build-index`；`[skip-index]` / 机器人提交 → `build-index-noop-<run_id>`；`workflow_dispatch`（无 `head_commit`）→ `build-index`。

未附带重建好的 `_index.json`：本次工作环境是浅克隆，`git log -1` 取不到真实提交时间，跑出来每条 `updatedAt` 都会被写成当前时间。CI 里有 `fetch-depth: 0`，合并后由它重建才是对的 —— 这次合并本身就会触发一趟 Build index，把漏掉的资源补进索引。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CH5Gt4WTB5MNtZ3FN3j1PP)_