### PR TITLE
fix(ci): 跳过标记改用 endsWith 匹配，别误伤普通提交

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -16,14 +16,17 @@ on:
 # 再判断 if。所以一个什么都不做的运行照样能取消掉真构建，自己再跳过，
 # 结果没人重建索引。要跳过的运行必须拿到各自独立的组名，别碰 build-index。
 concurrency:
-  group: "build-index${{ (contains(github.event.head_commit.message, '[skip-index]') || github.actor == 'github-actions[bot]') && format('-noop-{0}', github.run_id) || '' }}"
+  group: "build-index${{ (endsWith(github.event.head_commit.message, '[skip-index]') || github.actor == 'github-actions[bot]') && format('-noop-{0}', github.run_id) || '' }}"
   cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest
     # 机器人自己的提交只改 _index.json，跳过避免死循环；
-    # 送花只改 _flowers.json（提交带 [skip-index]），也不用重建索引
-    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip-index]')
+    # 送花只改 _flowers.json（提交带 [skip-index]），也不用重建索引。
+    # 用 endsWith 而不是 contains：标记是送花提交标题的结尾，而送花提交没有正文。
+    # contains 会连正文里顺嘴提到这个标记的普通提交一起跳过——本仓库真栽过一次，
+    # 那种漏掉是不报错的，索引就悄悄停在旧状态。
+    if: github.actor != 'github-actions[bot]' && !endsWith(github.event.head_commit.message, '[skip-index]')
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## 问题

上一个 PR（#164）的合并提交**把自己跳过了**：run #10196 结论是 `skipped`，索引没重建，只能手动 `workflow_dispatch` 补跑一趟（run #10197，成功）。

原因是 job 的 `if` 用 `contains` 匹配**整条**提交信息。#164 的 squash 提交正文里为了解释问题，原样引用了跳过标记这个字符串，于是被判成「这是一条送花提交」，直接跳过。

这类漏掉**不报错**：运行显示为 `skipped`，索引就悄悄停在旧状态 —— 跟 #164 修的是同一类静默失效。

## 改动

`contains` → `endsWith`，`if` 和 `concurrency` 两处都改。

依据：标记位于送花提交**标题的结尾**，且送花提交**没有正文**（抽查了近 30 条提交，正文长度全为 0），所以整条提交信息就是以标记结尾。正文里引用它的普通提交则不会以它结尾。

## 验证

`actionlint` 通过。四种情形的真值表：

| 情形 | job | concurrency 组 |
| --- | --- | --- |
| app 送花提交 | skipped | `build-index-noop-<run_id>` |
| app 上架提交 | 运行 | `build-index` |
| 正文提到标记的普通提交 | **运行**（原为 skipped） | `build-index` |
| 机器人自身提交 | skipped | `build-index-noop-<run_id>` |
| `workflow_dispatch` | 运行 | `build-index` |

另：#164 合并后索引已确认修复 —— `_index.json` 现有 146 条，此前漏掉的 `资源/快捷指令模版/打开微信并截图快捷指令` 已入索引（机器人提交 `1bb57bb`）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CH5Gt4WTB5MNtZ3FN3j1PP)_